### PR TITLE
Fixed groupBy with spaces in field declaration

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1194,7 +1194,7 @@ class MysqliDb
      */
     public function groupBy($groupByField)
     {
-        $groupByField = preg_replace("/[^-a-z0-9\.\(\),_\*]+/i", '', $groupByField);
+        $groupByField = preg_replace("/[^-a-z0-9\.\(\),_\* ]+/i", '', $groupByField);
 
         $this->_groupBy[] = $groupByField;
         return $this;

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1194,7 +1194,7 @@ class MysqliDb
      */
     public function groupBy($groupByField)
     {
-        $groupByField = preg_replace("/[^-a-z0-9\.\(\),_\* ]+/i", '', $groupByField);
+        $groupByField = preg_replace("/[^-a-z0-9\.\(\),_\* <>=!]+/i", '', $groupByField);
 
         $this->_groupBy[] = $groupByField;
         return $this;


### PR DESCRIPTION
Sometimes you have to use GROUP BY in SQL with Spaces in it.
The old implementation deleted all spaces in $groupByField
Eg "IF(qv.idValue IS NULL, UUID(), qv.idValue)" would become "IF(qv.idValueISNULL,UUID(),qv.idValue)"

In case of grouping all equal but not null values, you need a function call like in above example.

Example of stacktrace:
`Uncaught Exception: Unknown column 'qv.idValueISNULL' in 'group statement' query`