### PR TITLE
Manually populated fields

### DIFF
--- a/dbObject.php
+++ b/dbObject.php
@@ -146,7 +146,7 @@ class dbObject {
         if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) !== false)
 	    return null;
 		
-	if (isset ($this->data[$name]) && $this->data[$name] instanceof dbObject)
+	if (isset ($this->data[$name]))
             return $this->data[$name];
 
         if (property_exists ($this, 'relations') && isset ($this->relations[$name])) {


### PR DESCRIPTION
When a field is manually populated with data in hasMany relations this check will fail and will cause the field to be repopulated.