### PR TITLE
Revert "Now getInstance function will create new MysqliDb object if o…

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -428,11 +428,7 @@ class MysqliDb
      */
     public static function getInstance()
     {
-        if(isset(self::$_instance)) {
-            return self::$_instance;
-        } else {
-            return new MysqliDb();
-        }
+        return self::$_instance;
     }
 
     /**


### PR DESCRIPTION
…ne is not present. (#794)"

This reverts commit 43459aeaee2b98ef651da78f8a03ce22c23ebbeb.


----

There is no way that this cannot cause an error due to no connection settings. 

Connections are stored on an object and so therefore you cannot add a connection beforehand. With the instance being protected you cannot check its presence without using `getInstance()` - therefore `getInstance()` must always return the instance or nothing.

If there was a way of checking the instance as well as getting the instance that would be fine.