### PR TITLE
Fix bug related to store_result()

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1629,7 +1629,7 @@ class MysqliDb
 
         $row = array();
         while ($field = $meta->fetch_field()) {
-            if ($field->type == $mysqlLongType) {
+            if ($field->type == $mysqlLongType && version_compare(PHP_VERSION, '5.3') <= 0) {
                 $shouldStoreResult = true;
             }
 


### PR DESCRIPTION
Use `store_result()` and `free_result()` only if `PHP version <= 5.3`.
Related to [issue](https://github.com/ThingEngineer/PHP-MySQLi-Database-Class/issues/784) with multiple calls of stored procedures. 