### PR TITLE
Fix getOne() return value

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -769,7 +769,9 @@ class MysqliDb
             return $res[0];
         } elseif ($res) {
             return $res;
-        }
+        } elseif ($res === false) {
+	    return false;	
+	}
 
         return null;
     }


### PR DESCRIPTION
getOne() return value should return boolean false if there is an error, or null if there is an empty recordset