### PR TITLE
Fix implode() PHP 7.4

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1835,7 +1835,7 @@ class MysqliDb
         $dataColumns = array_keys($tableData);
         if ($isInsert) {
             if (isset ($dataColumns[0]))
-                $this->_query .= ' (`' . implode($dataColumns, '`, `') . '`) ';
+                $this->_query .= ' (`' . implode('`, `', $dataColumns) . '`) ';
             $this->_query .= ' VALUES (';
         } else {
             $this->_query .= " SET ";


### PR DESCRIPTION
implode(): Passing glue string after array is deprecated.

Fixes: #868 