### PR TITLE
Remove single quotes on null value

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -2042,6 +2042,9 @@ class MysqliDb
             }
             if ($val === null) {
                 $val = 'NULL';
+                $newStr .= substr($str, 0, $pos) . $val;
+            }else{
+                $newStr .= substr($str, 0, $pos) . "'" . $val . "'";
             }
             $newStr .= substr($str, 0, $pos) . "'" . $val . "'";
             $str = substr($str, $pos + 1);


### PR DESCRIPTION
Removed single quotes for NULL values on replacePlaceHolders() line 2043.
'NULL' value with quotes generated an error with date fields