### PR TITLE
Add DESCRIBE to rawAddPrefix

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -553,7 +553,7 @@ class MysqliDb
     public function rawAddPrefix($query){
         $query = str_replace(PHP_EOL, null, $query);
         $query = preg_replace('/\s+/', ' ', $query);
-        preg_match_all("/(from|into|update|join) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", $query, $matches);
+        preg_match_all("/(from|into|update|join|describe) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", $query, $matches);
         list($from_table, $from, $table) = $matches;
 
         return str_replace($table[0], self::$prefix.$table[0], $query);


### PR DESCRIPTION
Trying to get all fields in a table, I have an error saying Undefined index 0 on MysqliDb.php, line 559.
I am using `rawQuery("DESCRIBE table-name");`.  Looks like rawAddPrefix is not able to extract the table name because it doesn't look for the keyword 'describe', as it does for from, into, update and join.  This commis adds 'describe' in the list so we now can use DESCRIBE keyword and get all columns for a table.