### PR TITLE
#976 - fixed the issue number #976 by removing the space between function name and the parenthesis.

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -2096,7 +2096,7 @@ class MysqliDb
      *
      * @return int
      */
-    public function getLastErrno () {
+    public function getLastErrno() {
         return $this->_stmtErrno;
     }
 


### PR DESCRIPTION
Removed space before the parenthesis  of function getLastErrno to solve the issue #976