### PR TITLE
Update rawAddPrefix function

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -553,11 +553,9 @@ class MysqliDb
     public function rawAddPrefix($query){
         $query = str_replace(PHP_EOL, '', $query);
         $query = preg_replace('/\s+/', ' ', $query);
-        preg_match_all("/(from|into|update|join|describe) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", $query, $matches);
-        list($from_table, $from, $table) = $matches;
+        $query = preg_replace("/(from|into|update|join|describe) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", "\$1 " . self::$prefix . "\$2", $query);
 
-        $table = array_unique($table);
-        return str_replace($table, preg_filter('/^/', self::$prefix, $table), $query);
+        return $query;
     }
 
     /**

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -556,7 +556,8 @@ class MysqliDb
         preg_match_all("/(from|into|update|join|describe) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", $query, $matches);
         list($from_table, $from, $table) = $matches;
 
-        return str_replace($table[0], self::$prefix.$table[0], $query);
+        $table = array_unique($table);
+        return str_replace($table, preg_filter('/^/', self::$prefix, $table), $query);
     }
 
     /**


### PR DESCRIPTION
In the `rawAddPrefix` function, the prefix is added only to the first table in the query, if we have join and ... in the query, the prefix must be added to the names of all tables.

For example, query

    select t1.id as post_id, t2.id as bot_id from posts as t1 inner join bots as t2 on t1.bot_id = t2.id

is converted to

    select t1.id as post_id, t2.id as bot_id from tbl_posts as t1 inner join bots as t2 on t1.bot_id = t2.id

when it should be converted to 

    select t1.id as post_id, t2.id as bot_id from tbl_posts as t1 inner join tbl_bots as t2 on t1.bot_id = t2.id

This issue is resolved in this change.