### PR TITLE
Fix potential null issue in rawAddPrefix method

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -556,6 +556,10 @@ class MysqliDb
         preg_match_all("/(from|into|update|join|describe) [\\'\\´]?([a-zA-Z0-9_-]+)[\\'\\´]?/i", $query, $matches);
         list($from_table, $from, $table) = $matches;
 
+        // Check if there are matches
+        if (empty($table[0]))
+            return $query; 
+
         return str_replace($table[0], self::$prefix.$table[0], $query);
     }
 


### PR DESCRIPTION
This PR addresses a potential issue in the `rawAddPrefix` method where, if the provided SQL query does not contain keywords like "from", "into", "update", "join", or "describe" (e.g. functions and procedures), the `$table` array would be empty, leading to a PHP deprecated warning in the newer versions. 

The proposed solution adds a conditional check to ensure that there are table name matches before proceeding with the replacement.
