### PR TITLE
Fixed bug in new-v2.9.3 for wrong implode function use

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1835,7 +1835,7 @@ class MysqliDb
         $dataColumns = array_keys($tableData);
         if ($isInsert) {
             if (isset ($dataColumns[0]))
-                $this->_query .= ' (`' . implode($dataColumns, '`, `') . '`) ';
+                $this->_query .= ' (`' . implode('`, `', $dataColumns) . '`) ';
             $this->_query .= ' VALUES (';
         } else {
             $this->_query .= " SET ";


### PR DESCRIPTION
Hi, in the MysqliDb.php file and function "_buildInsertQuery" there is a wrong use of the implode function.