### PR TITLE
Fixes a PHP 8.4 Compatibility Issue

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -847,7 +847,7 @@ class MysqliDb
      * @return bool|array Boolean indicating the insertion failed (false), else return id-array ([int])
      * @throws Exception
      */
-    public function insertMulti($tableName, array $multiInsertData, array $dataKeys = null)
+    public function insertMulti($tableName, array $multiInsertData, ?array $dataKeys = null)
     {
         // only auto-commit our inserts, if no transaction is currently running
         $autoCommit = (isset($this->_transaction_in_progress) ? !$this->_transaction_in_progress : true);


### PR DESCRIPTION
MysqliDb::insertMulti(): Implicitly marking parameter $dataKeys as nullable is deprecated, the explicit nullable type must be used instead in MysqliDb.php on line 850.

Fixes ThingEngineer/PHP-MySQLi-Database-Class#1044