### PR TITLE
Fix PHP deprecation

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1427,7 +1427,7 @@ class MysqliDb
      */
     public function escape($str)
     {
-        return $this->mysqli()->real_escape_string($str);
+        return $str ? $this->mysqli()->real_escape_string($str) : $str;
     }
 
     /**


### PR DESCRIPTION
If null is passed to real_escape_string it throws a deprecation error, but null values would not need to be escaped regardless. This will return the null value rather than escaping.